### PR TITLE
Serving react build (#3)

### DIFF
--- a/skedge-backend/database-service.js
+++ b/skedge-backend/database-service.js
@@ -1,3 +1,12 @@
+//
+//
+// This module is only for the prototype.
+// It can be deleted by the database team whenever they're ready.
+//
+//
+
+
+
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 const ObjectId = Schema.ObjectId;

--- a/skedge-backend/index.js
+++ b/skedge-backend/index.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const bodyParser = require('body-parser');
+const path = require('path');
 const cors = require('cors');
 const app = express();
 const database_service = require('./database-service');
@@ -14,13 +15,12 @@ app.use(cors());
 // Using bodyParser.json() to automatically parse the body of 
 // incoming requests.
 app.use(bodyParser.json());
+// Using express.static to serve the React frontend at root.
+app.use(express.static(path.join(__dirname, '../skedge-frontend/build')));
 
 
  ///////////////////
 // Express Enpoints
-
-// Simple hello word GET endpoint at the root
-app.get('/', (req, res) => res.send('Hello World!'));
 
 // prototype endpoint
 app.put('/prototype', (req, res) => {

--- a/skedge-frontend/src/App.js
+++ b/skedge-frontend/src/App.js
@@ -16,7 +16,7 @@ class App extends Component {
 
   handleSubmit(){
     console.log('Request Sending, ' + this.state.value);
-    axios.put('http://localhost:4200/prototype', {"name": this.state.value})
+    axios.put('/prototype', {"name": this.state.value})
     .then(res => {
         this.setState({name: "works"});
         console.log(res);


### PR DESCRIPTION
* - serving react build from express
- can now write put("/prototype") instead of put("127.0.0.1/prototype")

* database-service.js is only for the prototype app. Can be deleted.